### PR TITLE
Lab 6: Let the shell substitute the var

### DIFF
--- a/labs/06_environment.md
+++ b/labs/06_environment.md
@@ -29,6 +29,9 @@ pipeline {
         stage('Greeting') {
             steps {
                 echo "Hello, ${env.GREETINGS_TO} !"
+
+                # also available as env variable to a process:
+                sh 'echo "Hello, $GREETINGS_TO !"'
             }
         }
     }
@@ -54,7 +57,10 @@ timestamps() {
         node {
             stage('Greeting') {
                 withEnv(['GREETINGS_TO=Jenkins Techlab']) {
-                    echo "Hello, ${env.GREETINGS_TO}!"
+                    echo "Hello, ${env.GREETINGS_TO} !"
+
+                    # also available as env variable to a process:
+                    sh 'echo "Hello, $GREETINGS_TO !"'
                 }
             }
         }


### PR DESCRIPTION
Instead of letting jenkins replace the env variable show
that it is available as environment variable to the shell.