### PR TITLE
Fix jdk

### DIFF
--- a/labs/08_tools.md
+++ b/labs/08_tools.md
@@ -25,11 +25,11 @@ Add a JDK:
 
 1. Go to Manage Jenkins > Global Tool Configuration
 2. Under JDK click `Add JDK`
-3. Under name enter `jdk8`
+3. Under name enter `jdk11`
 4. Check `Install automatically`
 5. Under `Add Installer` select `Extract *.zip/*.tar.gz`
-  * Under `Download URL for binary archive` enter: "https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz"
-  * Under `Subdirectory of extracted archive` enter: "java-se-8u41-ri"
+  * Under `Download URL for binary archive` enter: "https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz"
+  * Under `Subdirectory of extracted archive` enter: "jdk-11"
 6. At the bottom of the page click `Apply`
 
 Add Maven:

--- a/labs/08_tools.md
+++ b/labs/08_tools.md
@@ -54,7 +54,7 @@ pipeline {
         timestamps()  // Requires the "Timestamper Plugin"
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {
@@ -111,34 +111,6 @@ Jenkis can also use a container image as a build environment. In this case all t
     }
 
 We will use this method in `lab-15`
-
-
-Lab 8.2: Tools (Scripted Syntax)
-================================
-
-In scripted pipelines you use the ``tool`` step to install tools.
-Create a new branch named ``lab-8.2`` from branch ``lab-3.2`` and change the contents of the ``Jenkinsfile`` to:
-
-```groovy
-properties([
-    buildDiscarder(logRotator(numToKeepStr: '5'))
-])
-
-timestamps() {
-    timeout(time: 10, unit: 'MINUTES') {
-        node { // with hosted env use node(env.JOB_NAME.split('/')[0])
-            stage('Greeting') {
-                withEnv(["JAVA_HOME=${tool 'jdk8'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
-                    sh "java -version"
-                    sh "mvn --version"
-                }
-            }
-        }
-    }
-}
-```
-
-The usage of tools is identical to the previous lab since we couldn't use the declarative syntax there.
 
 ---
 

--- a/labs/09_artifacts.md
+++ b/labs/09_artifacts.md
@@ -30,13 +30,13 @@ pipeline {
         timestamps()  // Requires the "Timestamper Plugin"
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                 archiveArtifacts 'target/*.?ar'
                 junit 'target/**/*.xml'  // Requires JUnit plugin
             }

--- a/labs/10_failures.md
+++ b/labs/10_failures.md
@@ -36,7 +36,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                 archiveArtifacts 'target/*.?ar'
             }
             post {

--- a/labs/10_failures.md
+++ b/labs/10_failures.md
@@ -30,7 +30,7 @@ pipeline {
         timestamps()  // Requires the "Timestamper Plugin"
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {
@@ -67,56 +67,6 @@ Obviously we'll want eliminate the similar code in the global ``post`` directive
 The ``rawMesssage`` attribute of ``rocketSend`` tells Rocket.Chat not to add content on its own like link previews.
 
 **Note:** Check the message of your build in the Rocket.Chat channel.
-
-Lab 10.2: Failures (Scripted Syntax)
------------------------------------
-Create a new branch named ``lab-10.2`` from branch ``lab-9.2`` and change the content of the ``Jenkinsfile`` to:
-
-```groovy
-properties([
-    buildDiscarder(logRotator(numToKeepStr: '5'))
-])
-
-try {
-    timestamps() {
-        timeout(time: 10, unit: 'MINUTES') {
-            node { // with hosted env use node(env.JOB_NAME.split('/')[0])
-                stage('Build') {
-                    try {
-                        withEnv(["JAVA_HOME=${tool 'jdk8'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
-                            checkout scm
-                            sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
-                            archiveArtifacts 'target/*.?ar'
-                        }
-                    } finally {
-                        junit 'target/**/*.xml'  // Requires JUnit plugin
-                    }
-                }
-            }
-        }
-    }
-} catch (e) {
-    node {
-        rocketSend avatar: 'https://chat.puzzle.ch/emoji-custom/failure.png', channel: 'jenkins-techlab', message: "Build failure - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)", rawMessage: true
-    }
-    throw e
-} finally {
-    node {
-        if (currentBuild.result == 'UNSTABLE') {
-             rocketSend avatar: 'https://chat.puzzle.ch/emoji-custom/unstable.png', channel: 'jenkins-techlab', message: "Build unstable - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)", rawMessage: true
-        } else if (currentBuild.result == null) { // null means success
-            rocketSend avatar: 'https://chat.puzzle.ch/emoji-custom/success.png', channel: 'jenkins-techlab', message: "Build success - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)", rawMessage: true
-        }
-    }
-}
-```
-
-It's again good practice to ensure capture of test results in any case using a ``finally`` statement.
-
-The ``junit`` and ``rocketSend`` steps need a workspace and must be contained in a ``node`` step.
-
-**Note:** Check the message of your build in the Rocket.Chat channel.
-
 
 Lab 10.3: Mail notification
 ---------------------------

--- a/labs/11_shared_libs.md
+++ b/labs/11_shared_libs.md
@@ -64,7 +64,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                 archiveArtifacts 'target/*.?ar'
             }
             post {

--- a/labs/11_shared_libs.md
+++ b/labs/11_shared_libs.md
@@ -58,7 +58,7 @@ pipeline {
         timestamps()  // Requires the "Timestamper Plugin"
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {

--- a/labs/12_credentials.md
+++ b/labs/12_credentials.md
@@ -38,7 +38,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                 sh "mvn -s '${M2_SETTINGS}' -B deploy:deploy-file -DrepositoryId='puzzle-releases' -Durl='${REPO_URL}' -DgroupId='com.puzzleitc.jenkins-techlab' -DartifactId='${ARTIFACT}' -Dversion='1.0' -Dpackaging='jar' -Dfile=`echo target/*.jar`"
                 sshagent(['testserver']) {  // SSH Agent Plugin
                     sh "ls -l target"

--- a/labs/12_credentials.md
+++ b/labs/12_credentials.md
@@ -32,7 +32,7 @@ pipeline {
         REPO_URL = 'https://artifactory.puzzle.ch/artifactory/ext-release-local'
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {
@@ -61,50 +61,6 @@ In case of a secret file ``MYVARNAME`` contains the filename of a temporary file
 Additionally we make use of the ``sshagent`` step which managed a dedicated SSH agent with the requested
 credential loaded. This is more secure than writing the key into a file and also works in scenarios
 where support for alternate ssh key files is missing, e.g. when installing packages in private Git repos through npm.
-
-Lab 12.2: Credentials (Scripted Syntax)
----------------------------------------
-
-In scripted pipelines you access credentials through the ``withCredentials`` step and various
-helper methods like ``usernameColonPassword`` or ``file``.
-Create a new branch named ``lab-12.2`` from branch
-``lab-9.2`` and change the content of the ``Jenkinsfile`` to:
-
-```groovy
-properties([
-    buildDiscarder(logRotator(numToKeepStr: '5'))
-])
-
-timestamps() {
-    timeout(time: 10, unit: 'MINUTES') {
-        env.ARTIFACT = "${env.JOB_NAME.split('/')[0]}-hello"
-        env.REPO_URL = 'https://artifactory.puzzle.ch/artifactory/ext-release-local'
-        node { // with hosted env use node(env.JOB_NAME.split('/')[0])
-            withCredentials([file(credentialsId: 'm2_settings', variable: 'M2_SETTINGS'), usernameColonPassword(credentialsId: 'jenkins-artifactory', variable: 'ARTIFACTORY'), file(credentialsId: 'known_hosts', variable: 'KNOWN_HOSTS')]) {  // Credentials Binding Plugin
-                withEnv(["JAVA_HOME=${tool 'jdk8'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
-                    stage('Build') {
-                        checkout scm
-                        sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
-                        sh "mvn -s '${M2_SETTINGS}' -B deploy:deploy-file -DrepositoryId='puzzle-releases' -Durl='${REPO_URL}' -DgroupId='com.puzzleitc.jenkins-techlab' -DartifactId='${ARTIFACT}' -Dversion='1.0' -Dpackaging='jar' -Dfile=`echo target/*.jar`"
-                        sshagent(['testserver']) {  // SSH Agent Plugin
-                            sh "ls -l target"
-                            sh "ssh -o UserKnownHostsFile='${KNOWN_HOSTS}' -p 2222 richard@testserver.vcap.me 'curl -O -u \'${ARTIFACTORY}\' ${REPO_URL}/com/puzzleitc/jenkins-techlab/${ARTIFACT}/1.0/${ARTIFACT}-1.0.jar && ls -l'"
-                        }
-                        archiveArtifacts 'target/*.?ar'
-                        junit 'target/**/*.xml'  // Requires JUnit plugin
-                    }
-                }
-            }
-        }
-    }
-}
-```
-
-With ``withCredentials`` you have to use the helper method corresponding to the credential type
-you are accessing. See <https://jenkins.io/doc/pipeline/steps/credentials-binding/#withcredentials-bind-credentials-to-variables>
-for more information. The available credential types depend on the plugins installed. Visit the ``/pipeline-syntax/`` path
-on your server to see only what's actually available, e.g. <https://jenkins-techlab.ose3-lab.puzzle.ch/pipeline-syntax/>
-for this techlab.
 
 ---
 

--- a/labs/13_stages_locks_milestones.md
+++ b/labs/13_stages_locks_milestones.md
@@ -46,7 +46,7 @@ pipeline {
             steps {
                 // Only one build is allowed to use test resources, newest builds run first
                 lock(resource: 'myResource', inversePrecedence: true) {  // Lockable Resources Plugin
-                    sh 'mvn -B -V -U -e verify -Dsurefire.useFile=false'
+                    sh 'mvn -B -V -U -e verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                     milestone(20)  // Abort all older builds that didn't get here
                 }
             }

--- a/labs/13_stages_locks_milestones.md
+++ b/labs/13_stages_locks_milestones.md
@@ -32,7 +32,7 @@ pipeline {
         REPO_URL = 'https://artifactory.puzzle.ch/artifactory/ext-release-local'
     }
     tools {
-        jdk 'jdk8'
+        jdk 'jdk11'
         maven 'maven35'
     }
     stages {
@@ -85,11 +85,6 @@ in test stages. While ``input`` pauses a build and waits for user input.
 It accepts the same parameters type as build parameters but can appear
 anywhere in a build and allows the parameters to be computed.  
 See <https://jenkins.io/blog/2016/10/16/stage-lock-milestone/> for more information.
-
-Lab 13.2: Stages, Locks and Milestones (Scripted Syntax)
---------------------------------------------------------
-
-Adapt scripted pipeline from previous lab analogously.
 
 ---
 

--- a/labs/scripted/08_scripted_tools.md
+++ b/labs/scripted/08_scripted_tools.md
@@ -1,0 +1,26 @@
+Lab 8.2: Tools (Scripted Syntax)
+================================
+
+In scripted pipelines you use the ``tool`` step to install tools.
+Create a new branch named ``lab-8.2`` from branch ``lab-3.2`` and change the contents of the ``Jenkinsfile`` to:
+
+```groovy
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5'))
+])
+
+timestamps() {
+    timeout(time: 10, unit: 'MINUTES') {
+        node { // with hosted env use node(env.JOB_NAME.split('/')[0])
+            stage('Greeting') {
+                withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                    sh "java -version"
+                    sh "mvn --version"
+                }
+            }
+        }
+    }
+}
+```
+
+The usage of tools is identical to the previous lab since we couldn't use the declarative syntax there.

--- a/labs/scripted/09_scripted_artifacts.md
+++ b/labs/scripted/09_scripted_artifacts.md
@@ -16,7 +16,7 @@ timestamps() {
             stage('Build') {
                 withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     checkout scm
-                    sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                    sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                     archiveArtifacts 'target/*.?ar'
                     junit 'target/**/*.xml'  // Requires JUnit plugin
                 }

--- a/labs/scripted/09_scripted_artifacts.md
+++ b/labs/scripted/09_scripted_artifacts.md
@@ -1,0 +1,37 @@
+Lab 9.2: Artifact Archival (Scripted Syntax)
+--------------------------------------------
+
+In scripted pipelines you too use the ``archive`` or ``archiveArtifact`` step for artifact archival.
+Create a new branch named ``lab-9.2`` from branch ``lab-9.1`` (the one
+we merged the source into) and change the contents of the ``Jenkinsfile`` to:
+
+```groovy
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5'))
+])
+
+timestamps() {
+    timeout(time: 10, unit: 'MINUTES') {
+        node { // with hosted env use node(env.JOB_NAME.split('/')[0])
+            stage('Build') {
+                withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                    checkout scm
+                    sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                    archiveArtifacts 'target/*.?ar'
+                    junit 'target/**/*.xml'  // Requires JUnit plugin
+                }
+            }
+        }
+    }
+}
+```
+
+In scripted pipelines you have to check out the repository containing the jobs ``Jenkinsfile``
+with ``checkout scm``. ``scm`` is a variable referencing the repository containing the ``Jenkinsfile``.  
+``junit`` is a special artifact archival step which provides special support
+for JUnit test reports. Is is also useful outside of JUnit as there are other tools
+which generate JUnit test reports, e.g. Selenium or SoapUI.
+These examples use the recommended options for Maven in pipeline jobs.
+See <https://jenkins.io/doc/pipeline/examples/#maven-and-jdk-specific-version> for details.
+
+**Note:** Check the pipeline screen and build log output on the Jenkins master. The build has also an additional "Test Result" link.

--- a/labs/scripted/10_scripted_failures.md
+++ b/labs/scripted/10_scripted_failures.md
@@ -15,7 +15,7 @@ try {
                     try {
                         withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                             checkout scm
-                            sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                            sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                             archiveArtifacts 'target/*.?ar'
                         }
                     } finally {

--- a/labs/scripted/10_scripted_failures.md
+++ b/labs/scripted/10_scripted_failures.md
@@ -1,0 +1,48 @@
+Lab 10.2: Failures (Scripted Syntax)
+-----------------------------------
+Create a new branch named ``lab-10.2`` from branch ``lab-9.2`` and change the content of the ``Jenkinsfile`` to:
+
+```groovy
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5'))
+])
+
+try {
+    timestamps() {
+        timeout(time: 10, unit: 'MINUTES') {
+            node { // with hosted env use node(env.JOB_NAME.split('/')[0])
+                stage('Build') {
+                    try {
+                        withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                            checkout scm
+                            sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                            archiveArtifacts 'target/*.?ar'
+                        }
+                    } finally {
+                        junit 'target/**/*.xml'  // Requires JUnit plugin
+                    }
+                }
+            }
+        }
+    }
+} catch (e) {
+    node {
+        rocketSend avatar: 'https://chat.puzzle.ch/emoji-custom/failure.png', channel: 'jenkins-techlab', message: "Build failure - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)", rawMessage: true
+    }
+    throw e
+} finally {
+    node {
+        if (currentBuild.result == 'UNSTABLE') {
+             rocketSend avatar: 'https://chat.puzzle.ch/emoji-custom/unstable.png', channel: 'jenkins-techlab', message: "Build unstable - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)", rawMessage: true
+        } else if (currentBuild.result == null) { // null means success
+            rocketSend avatar: 'https://chat.puzzle.ch/emoji-custom/success.png', channel: 'jenkins-techlab', message: "Build success - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)", rawMessage: true
+        }
+    }
+}
+```
+
+It's again good practice to ensure capture of test results in any case using a ``finally`` statement.
+
+The ``junit`` and ``rocketSend`` steps need a workspace and must be contained in a ``node`` step.
+
+**Note:** Check the message of your build in the Rocket.Chat channel.

--- a/labs/scripted/12_scripted_credentials.md
+++ b/labs/scripted/12_scripted_credentials.md
@@ -20,7 +20,7 @@ timestamps() {
                 withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     stage('Build') {
                         checkout scm
-                        sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                        sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true"'
                         sh "mvn -s '${M2_SETTINGS}' -B deploy:deploy-file -DrepositoryId='puzzle-releases' -Durl='${REPO_URL}' -DgroupId='com.puzzleitc.jenkins-techlab' -DartifactId='${ARTIFACT}' -Dversion='1.0' -Dpackaging='jar' -Dfile=`echo target/*.jar`"
                         sshagent(['testserver']) {  // SSH Agent Plugin
                             sh "ls -l target"

--- a/labs/scripted/12_scripted_credentials.md
+++ b/labs/scripted/12_scripted_credentials.md
@@ -1,0 +1,43 @@
+Lab 12.2: Credentials (Scripted Syntax)
+---------------------------------------
+
+In scripted pipelines you access credentials through the ``withCredentials`` step and various
+helper methods like ``usernameColonPassword`` or ``file``.
+Create a new branch named ``lab-12.2`` from branch
+``lab-9.2`` and change the content of the ``Jenkinsfile`` to:
+
+```groovy
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5'))
+])
+
+timestamps() {
+    timeout(time: 10, unit: 'MINUTES') {
+        env.ARTIFACT = "${env.JOB_NAME.split('/')[0]}-hello"
+        env.REPO_URL = 'https://artifactory.puzzle.ch/artifactory/ext-release-local'
+        node { // with hosted env use node(env.JOB_NAME.split('/')[0])
+            withCredentials([file(credentialsId: 'm2_settings', variable: 'M2_SETTINGS'), usernameColonPassword(credentialsId: 'jenkins-artifactory', variable: 'ARTIFACTORY'), file(credentialsId: 'known_hosts', variable: 'KNOWN_HOSTS')]) {  // Credentials Binding Plugin
+                withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                    stage('Build') {
+                        checkout scm
+                        sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false'
+                        sh "mvn -s '${M2_SETTINGS}' -B deploy:deploy-file -DrepositoryId='puzzle-releases' -Durl='${REPO_URL}' -DgroupId='com.puzzleitc.jenkins-techlab' -DartifactId='${ARTIFACT}' -Dversion='1.0' -Dpackaging='jar' -Dfile=`echo target/*.jar`"
+                        sshagent(['testserver']) {  // SSH Agent Plugin
+                            sh "ls -l target"
+                            sh "ssh -o UserKnownHostsFile='${KNOWN_HOSTS}' -p 2222 richard@testserver.vcap.me 'curl -O -u \'${ARTIFACTORY}\' ${REPO_URL}/com/puzzleitc/jenkins-techlab/${ARTIFACT}/1.0/${ARTIFACT}-1.0.jar && ls -l'"
+                        }
+                        archiveArtifacts 'target/*.?ar'
+                        junit 'target/**/*.xml'  // Requires JUnit plugin
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+With ``withCredentials`` you have to use the helper method corresponding to the credential type
+you are accessing. See <https://jenkins.io/doc/pipeline/steps/credentials-binding/#withcredentials-bind-credentials-to-variables>
+for more information. The available credential types depend on the plugins installed. Visit the ``/pipeline-syntax/`` path
+on your server to see only what's actually available, e.g. <https://jenkins-techlab.ose3-lab.puzzle.ch/pipeline-syntax/>
+for this techlab.

--- a/labs/scripted/13_scripted_stage_locks_milestones.md
+++ b/labs/scripted/13_scripted_stage_locks_milestones.md
@@ -1,0 +1,4 @@
+Lab 13.2: Stages, Locks and Milestones (Scripted Syntax)
+--------------------------------------------------------
+
+Adapt scripted pipeline from previous lab analogously.

--- a/labs/solutions/10_3_failures_solution.md
+++ b/labs/solutions/10_3_failures_solution.md
@@ -27,7 +27,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                withEnv(["JAVA_HOME=${tool 'jdk8_oracle'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                     sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -Dmaven.test.failure.ignore=true'
                     archiveArtifacts 'target/*.?ar'
                 }
@@ -78,7 +78,7 @@ try {
             node(env.JOB_NAME.split('/')[0]) {
                 stage('Build') {
                     try {
-                        withEnv(["JAVA_HOME=${tool 'jdk8_oracle'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
+                        withEnv(["JAVA_HOME=${tool 'jdk11'}", "PATH+MAVEN=${tool 'maven35'}/bin:${env.JAVA_HOME}/bin"]) {
                             checkout scm
                             sh 'mvn -B -V -U -e clean verify -Dsurefire.useFile=false -Dmaven.test.failure.ignore=true'
                             archiveArtifacts 'target/*.?ar'


### PR DESCRIPTION
Bump OpenJDK to version 11 [(Newer OpenJDK than v10 includes root ca certs)](https://blogs.oracle.com/jtc/openjdk-10-now-includes-root-ca-certificates)
Disable class path URL check to avoid surefire crash ([Source](https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class))