### PR TITLE
Fix local_env agent image build

### DIFF
--- a/local_env/agent/Dockerfile
+++ b/local_env/agent/Dockerfile
@@ -7,6 +7,7 @@ ARG docker_version=18.06.3-ce
 RUN wget -qO- ${docker_url}docker-${docker_version}.tgz | \
 	tar zxvf - --strip 1 -C /usr/bin docker/docker
 
+# build final image
 FROM jenkins/ssh-agent 
 
 # install git
@@ -14,5 +15,5 @@ RUN apt-get update && apt-get install -y \
 	git \
 	&& rm -rf /var/lib/apt/lists/*
 
-# copy docker from downloader
+# copy docker from "downloader" build stage
 COPY --from=downloader /usr/bin/docker /usr/bin/docker

--- a/local_env/agent/Dockerfile
+++ b/local_env/agent/Dockerfile
@@ -1,8 +1,13 @@
-FROM jenkins/ssh-agent
+FROM alpine:latest AS downloader
 
 ARG docker_url=https://download.docker.com/linux/static/stable/x86_64/
 ARG docker_version=18.06.3-ce
 
-# install docker cli
-RUN curl -fsSL ${docker_url}docker-${docker_version}.tgz | \
+# download and untar docker cli
+RUN wget -qO- ${docker_url}docker-${docker_version}.tgz | \
 tar zxvf - --strip 1 -C /usr/bin docker/docker
+
+FROM jenkins/ssh-agent 
+
+# copy docker from downloader
+COPY --from=downloader /usr/bin/docker /usr/bin/docker

--- a/local_env/agent/Dockerfile
+++ b/local_env/agent/Dockerfile
@@ -5,9 +5,14 @@ ARG docker_version=18.06.3-ce
 
 # download and untar docker cli
 RUN wget -qO- ${docker_url}docker-${docker_version}.tgz | \
-tar zxvf - --strip 1 -C /usr/bin docker/docker
+	tar zxvf - --strip 1 -C /usr/bin docker/docker
 
 FROM jenkins/ssh-agent 
+
+# install git
+RUN apt-get update && apt-get install -y \
+	git \
+	&& rm -rf /var/lib/apt/lists/*
 
 # copy docker from downloader
 COPY --from=downloader /usr/bin/docker /usr/bin/docker


### PR DESCRIPTION
In newer versions of the image `jenkins/ssh-agent` `curl` and `git` are missing.

I propose a multistage build to download and extract `docker` and the installation of `git`.

We may want to explicitly tag `jenkins/ssh-agent`?