### PR TITLE
upgrade jenkins version to 2.375.1

### DIFF
--- a/local_env/master/Dockerfile
+++ b/local_env/master/Dockerfile
@@ -1,11 +1,11 @@
-FROM jenkins/jenkins:2.319.3
+FROM jenkins/jenkins:2.375.1
 
 # skip the setup wizard
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false -Dpermissive-script-security.enabled=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
 
 # install plugins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt
 
 USER root
 

--- a/local_env/master/jenkins.yaml
+++ b/local_env/master/jenkins.yaml
@@ -31,8 +31,6 @@ unclassified:
   location:
     adminAddress: "address not configured yet <nobody@nowhere>"
     url: "http://localhost:8080/"
-  pipeline-model-docker:
-    dockerLabel: "docker"
 credentials:
   system:
     domainCredentials:


### PR DESCRIPTION
Plugins were not installed anymore in the setup step because of an old Jenkins version 2.319.3 which was not anymore supported by the plugins. 