### PR TITLE
fix compatibility issues during techlab exec

### DIFF
--- a/local_env/create-ssh-keys.sh
+++ b/local_env/create-ssh-keys.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ssh-keygen -t rsa -b 4096 -N "" -f techlab.key -C ""
+ssh-keygen -t ed25519 -N "" -f techlab.key -C ""
 
 TECHLAB_PUBLIC_KEY="$(cat techlab.key.pub)"
 

--- a/local_env/master/Dockerfile
+++ b/local_env/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.375.1
+FROM jenkins/jenkins:jdk11
 
 # skip the setup wizard
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false -Dpermissive-script-security.enabled=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"

--- a/local_env/master/Dockerfile
+++ b/local_env/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:jdk11
+FROM jenkins/jenkins:lts-jdk11
 
 # skip the setup wizard
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false -Dpermissive-script-security.enabled=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"

--- a/local_env/master/jenkins.yaml
+++ b/local_env/master/jenkins.yaml
@@ -11,8 +11,6 @@ jenkins:
   authorizationStrategy:
     loggedInUsersCanDoAnything:
       allowAnonymousRead: false
-  remotingSecurity:
-    enabled: true
   nodes:
   - permanent:
       name: "ssh-agent-docker"
@@ -23,7 +21,7 @@ jenkins:
       launcher:
         ssh:
           credentialsId: "bf5bb957-18bc-45ca-baa8-e7e3cb652405"
-          host: "jenkins_slave_docker"
+          host: "jenkins_agent_docker"
           port: 22
           javaPath: "^${JAVA_HOME}/bin/java"
           sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"


### PR DESCRIPTION
fixing issues during techlab execution 
(jenkins version / plugin compatibility > Dockerfile)
(dated rsa would not work after upgrade > ssh-keys.sh)
(naming issue for agents > jenkins.yaml)
(https://www.jenkins.io/doc/book/security/controller-isolation/jep-235/ > jenkins.yaml)